### PR TITLE
Fix getGlobalRepository Return Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Type `FindConditions`, now sub-entities also accept FindOperators.
+- [BC] `getGlobalRepository` return type
+  - Now receives a `Repository` as type, instead an `Entity`
+  - Ex: `getGlobalRepository<Entity>(Entity)` -> `getGlobalRepository<EntityRepository>(Entity)`
 
 ### Removed
 

--- a/src/lib/utils/globals/get-global-repository.ts
+++ b/src/lib/utils/globals/get-global-repository.ts
@@ -1,10 +1,11 @@
+import { BaseRepository } from "../../repository";
 import { getGlobalConnection } from "./get-global-connection";
 
-export const getGlobalRepository = <Entity>(
+export const getGlobalRepository = <Repository extends BaseRepository<any>>(
 	entity: any,
 	connectionName?: string,
 ) => {
 	const connection = getGlobalConnection(connectionName);
 
-	return connection.getRepository<Entity>(entity);
+	return connection.getRepository(entity) as unknown as Repository;
 };


### PR DESCRIPTION
## What this PR introduces?

Issue Number: N/A
PR Of Documentation Update: N/A

<!-- Please, includes description of this pull request -->

### Fixed

- [BC] `getGlobalRepository` return type
  - Now receives a `Repository` as type, instead an `Entity`
  - Ex: `getGlobalRepository<Entity>(Entity)` -> `getGlobalRepository<EntityRepository>(Entity)`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] My contribution follows [the guidelines](https://github.com/techmmunity/symbiosis/blob/master/CONTRIBUTING.md)
- [x] I followed [GitFlow](https://github.com/techmmunity/git-magic/blob/master/docs/en/gitflow.md) pattern to create the branch
- [x] Tests for the changes have been added
- [x] I created a PR to add / update the documentation (or aren't necessary)
- [x] The changes has been added to `CHANGELOG.md`
- [x] My code produces no warnings or errors

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[x] Bugfix
[ ] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
[ ] Other: ...
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- `getGlobalRepository<Entity>(Entity)` -> `getGlobalRepository<EntityRepository>(Entity)`

## Other information (Prints, details, etc)
