### PR TITLE
Upgrade Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Removed
+
+### Dependencies
+
+## [0.0.28] - 2021-11-16
+
+### Added
+
+### Changed
+
+### Fixed
+
 - Type `FindConditions`, now sub-entities also accept FindOperators.
 - [BC] `getGlobalRepository` return type
   - Now receives a `Repository` as type, instead an `Entity`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@techmmunity/symbiosis",
-	"version": "0.0.27",
+	"version": "0.0.28",
 	"main": "index.js",
 	"types": "index.d.ts",
 	"license": "Apache-2.0",

--- a/src/lib/connection/index.ts
+++ b/src/lib/connection/index.ts
@@ -47,7 +47,7 @@ export abstract class BaseConnection<
 	protected isLoaded: boolean;
 
 	/**
-	 * "Constructor"
+	 * Constructor
 	 */
 
 	public constructor(
@@ -90,7 +90,7 @@ export abstract class BaseConnection<
 	}
 
 	/**
-	 * Methods
+	 * Abstract Methods
 	 */
 
 	public abstract connect(): Promise<void>;


### PR DESCRIPTION
## [0.0.28] - 2021-11-16

### Added

### Changed

### Fixed

- Type `FindConditions`, now sub-entities also accept FindOperators.
- [BC] `getGlobalRepository` return type
  - Now receives a `Repository` as type, instead an `Entity`
  - Ex: `getGlobalRepository<Entity>(Entity)` -> `getGlobalRepository<EntityRepository>(Entity)`

### Removed