### PR TITLE
Make save And insert Types Smarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [BC] `save` and `insert` doesn't need the extra type info anymore
+  - `.save<Array<Entity>>([data])` -> `.save([data])`
+  - `.save<Entity>(data)` -> `.save(data)`
+  - `.insert<Array<Entity>>([data])` -> `.insert([data])`
+  - `.insert<Entity>(data)` -> `.insert(data)`
+
 ### Fixed
 
 ### Removed

--- a/src/lib/repository/index.ts
+++ b/src/lib/repository/index.ts
@@ -36,7 +36,7 @@ import {
 	BeforePerformativeCountParams,
 	beforePerformativeCount,
 } from "./methods/before-performative-count";
-import { SaveData, SingleSaveData } from "./types/save-conditions";
+import type { SingleSaveData, ArraySaveData } from "./types/save-conditions";
 import { Logger } from "../logger";
 
 export abstract class BaseRepository<
@@ -80,36 +80,44 @@ export abstract class BaseRepository<
 	 * This is an more performative way to make an "upsert",
 	 * and most of the databases supports this method.
 	 */
-	public abstract save<Result = Array<Entity> | Entity>(
-		data: SaveData<Entity>,
+	public abstract save(
+		data: SingleSaveData<Entity>,
 		options?: BaseQueryOptions,
-	): Promise<Result>;
+	): Promise<Entity>;
+	public abstract save(
+		data: ArraySaveData<Entity>,
+		options?: BaseQueryOptions,
+	): Promise<Array<Entity>>;
 
 	/**
 	 * Inserts a record on the database and fail if it's already exist.
 	 */
-	public abstract insert<Result = Array<Entity> | Entity>(
-		data: SaveData<Entity>,
+	public abstract insert(
+		data: SingleSaveData<Entity>,
 		options?: BaseQueryOptions,
-	): Promise<Result>;
+	): Promise<Entity>;
+	public abstract insert(
+		data: ArraySaveData<Entity>,
+		options?: BaseQueryOptions,
+	): Promise<Array<Entity>>;
 
 	/**
 	 * Updates a record based on a query and fail if it's not exist.
 	 */
-	public abstract update<Result = Array<Entity> | Entity>(
+	public abstract update(
 		conditions: FindConditions<Entity>,
 		data: SingleSaveData<Entity>,
 		options?: BaseQueryOptions,
-	): Promise<Result>;
+	): Promise<Entity>;
 
 	/**
 	 * Make an "upsert" operation based on a query.
 	 */
-	public abstract upsert<Result = Array<Entity> | Entity>(
+	public abstract upsert(
 		conditions: FindConditions<Entity>,
 		data: SingleSaveData<Entity>,
 		options?: BaseQueryOptions,
-	): Promise<Result>;
+	): Promise<Entity>;
 
 	/**
 	 * --------------------------------------------------


### PR DESCRIPTION
## What this PR introduces?

Issue Number: N/A
PR Of Documentation Update: N/A

<!-- Please, includes description of this pull request -->

### Changed

- [BC] `save` and `insert` doesn't need the extra type info anymore
  - `.save<Array<Entity>>([data])` -> `.save([data])`
  - `.save<Entity>(data)` -> `.save(data)`
  - `.insert<Array<Entity>>([data])` -> `.insert([data])`
  - `.insert<Entity>(data)` -> `.insert(data)`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] My contribution follows [the guidelines](https://github.com/techmmunity/symbiosis/blob/master/CONTRIBUTING.md)
- [x] I followed [GitFlow](https://github.com/techmmunity/git-magic/blob/master/docs/en/gitflow.md) pattern to create the branch
- [x] Tests for the changes have been added
- [x] I created a PR to add / update the documentation (or aren't necessary)
- [x] The changes has been added to `CHANGELOG.md`
- [x] My code produces no warnings or errors

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
[ ] Other: ...
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information (Prints, details, etc)
