### PR TITLE
Standardize `upsert` and `update` returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `.save<Entity>(data)` -> `.save(data)`
   - `.insert<Array<Entity>>([data])` -> `.insert([data])`
   - `.insert<Entity>(data)` -> `.insert(data)`
+- [BC] Standardize `upsert` and `update` returns
+  - Will now only return **arrays**
 
 ### Fixed
 

--- a/src/lib/repository/index.ts
+++ b/src/lib/repository/index.ts
@@ -108,7 +108,7 @@ export abstract class BaseRepository<
 		conditions: FindConditions<Entity>,
 		data: SingleSaveData<Entity>,
 		options?: BaseQueryOptions,
-	): Promise<Entity>;
+	): Promise<Array<Entity>>;
 
 	/**
 	 * Make an "upsert" operation based on a query.
@@ -117,7 +117,7 @@ export abstract class BaseRepository<
 		conditions: FindConditions<Entity>,
 		data: SingleSaveData<Entity>,
 		options?: BaseQueryOptions,
-	): Promise<Entity>;
+	): Promise<Array<Entity>>;
 
 	/**
 	 * --------------------------------------------------


### PR DESCRIPTION
## What this PR introduces?

Issue Number: N/A
PR Of Documentation Update: N/A

<!-- Please, includes description of this pull request -->

### Changed

- [BC] Standardize `upsert` and `update` returns
  - Will now only return **arrays**

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] My contribution follows [the guidelines](https://github.com/techmmunity/symbiosis/blob/master/CONTRIBUTING.md)
- [x] I followed [GitFlow](https://github.com/techmmunity/git-magic/blob/master/docs/en/gitflow.md) pattern to create the branch
- [x] Tests for the changes have been added
- [x] I created a PR to add / update the documentation (or aren't necessary)
- [x] The changes has been added to `CHANGELOG.md`
- [x] My code produces no warnings or errors

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
[ ] Other: ...
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`upsert` and `update` must returns only **arrays**

## Other information (Prints, details, etc)
