### PR TITLE
Change connect Method Return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `.insert<Entity>(data)` -> `.insert(data)`
 - [BC] Standardize `upsert` and `update` returns
   - Will now only return **arrays**
+- [BC] Update `connect` method to return `this` instead `void`
+  - This way users can chain the methods
+  - Ex: `const connection = await new Connection().load().connect()`
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"tiny-glob": "^0.2.9"
 	},
 	"devDependencies": {
-		"@techmmunity/eslint-config": "^5.1.2",
+		"@techmmunity/eslint-config": "^5.1.3",
 		"@types/jest": "^27.0.2",
 		"@types/uuid": "^8.3.1",
 		"@vercel/ncc": "^0.31.1",

--- a/src/lib/connection/index.ts
+++ b/src/lib/connection/index.ts
@@ -93,7 +93,7 @@ export abstract class BaseConnection<
 	 * Abstract Methods
 	 */
 
-	public abstract connect(): Promise<void>;
+	public abstract connect(): Promise<this>;
 
 	public abstract close(): Promise<void>;
 

--- a/src/tests/constants/test-connection.ts
+++ b/src/tests/constants/test-connection.ts
@@ -11,7 +11,7 @@ export class TestConnection extends BaseConnection {
 		super("@techmmunity/utils", options);
 	}
 
-	public connect(): Promise<void> {
+	public connect(): Promise<this> {
 		throw new Error("Method not implemented.");
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,10 +584,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@techmmunity/eslint-config@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@techmmunity/eslint-config/-/eslint-config-5.1.2.tgz#d055bc2da408f565a16d63a97178f0c817d72942"
-  integrity sha512-Ot2qmO8QKTOrYWQDy2ARpwbvikUYGdPEarARL7Icjwql0+33CsRUEEBJaqAeLzVwVq0nfPbsjHHgUfpvUgF+LA==
+"@techmmunity/eslint-config@^5.1.3":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@techmmunity/eslint-config/-/eslint-config-5.1.3.tgz#dc8b0ccfd2322d7414d927da2c84a3dab6c3c3b3"
+  integrity sha512-Pfwpsb444XVe4iDNbPPF2/+RAM5DCoBbx4WH9Bg3TE+4J3RzCJCZVrXbSbvrMW4gHbWoaC9lQNJzqQVAoztkRw==
   dependencies:
     "@babel/core" "^7.15.5"
     "@babel/eslint-parser" "^7.15.4"


### PR DESCRIPTION
## What this PR introduces?

Issue Number: N/A
PR Of Documentation Update: N/A

<!-- Please, includes description of this pull request -->

- [BC] Update `connect` method to return `this` instead `void`
  - This way users can chain the methods
  - Ex: `const connection = await new Connection().load().connect()`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] My contribution follows [the guidelines](https://github.com/techmmunity/symbiosis/blob/master/CONTRIBUTING.md)
- [x] I followed [GitFlow](https://github.com/techmmunity/git-magic/blob/master/docs/en/gitflow.md) pattern to create the branch
- [x] Tests for the changes have been added
- [x] I created a PR to add / update the documentation (or aren't necessary)
- [x] The changes has been added to `CHANGELOG.md`
- [x] My code produces no warnings or errors

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
[ ] Other: ...
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`connect` method return `this` instead `void`

## Other information (Prints, details, etc)
