### PR TITLE
Add `validate` to `BaseConnection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [BC] `validate` method to `BaseConnection`
+  - Will be used to validate connection data
+  - Ex: If mongodb plugin, validate if all entities have only one primary column, and it's name is `_id`
+
 ### Changed
 
 - [BC] `save` and `insert` doesn't need the extra type info anymore

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,7 @@ module.exports = {
 	coverageThreshold: {
 		global: {
 			statements: 100,
-			branches: 99.65,
+			branches: 100,
 			functions: 100,
 			lines: 100,
 		},

--- a/src/tests/connection/index.spec.ts
+++ b/src/tests/connection/index.spec.ts
@@ -4,100 +4,159 @@ import { Entity } from "../../lib/decorators/entities/entity";
 import { PrimaryColumn } from "../../lib/decorators/columns/primary-column";
 import { Logger } from "../../lib/logger";
 import { TestConnection } from "../constants/test-connection";
+import { SymbiosisError } from "../..";
 
-describe("Connection > entity", () => {
-	it("should get connection default config", async () => {
-		@Entity()
-		class TestEntity {
-			@PrimaryColumn()
-			public id: string;
+describe("Connection", () => {
+	const plugin = "@techmmunity/utils";
 
-			@Column()
-			public foo: number;
-		}
+	describe("Connection `constructor` & `load`", () => {
+		it("should load empty array of entities", async () => {
+			const options: BaseConnectionOptions = {
+				entitiesDir: [],
+			};
 
-		const options: BaseConnectionOptions = {
-			entities: [TestEntity],
-		};
+			const connection = new TestConnection(options);
+			await connection.load();
 
-		const connection = new TestConnection(options);
-		await connection.load();
-
-		expect(connection.name).toBe("Default");
-		expect(connection.options).toStrictEqual({
-			plugin: "@techmmunity/utils",
+			expect(connection.name).toBe("Default");
+			expect(connection.options).toStrictEqual({
+				plugin,
+			});
+			expect(connection.entities).toStrictEqual([]);
+			expect(connection.options).not.toHaveProperty("entities");
+			expect(connection.options).not.toHaveProperty("entitiesDir");
+			expect(connection.logger instanceof Logger).toBeTruthy();
+			expect(connection.entityManager.entities).toStrictEqual({});
 		});
-		expect(connection.entities).toStrictEqual(options.entities);
-		expect(connection.options).not.toHaveProperty("entities");
-		expect(connection.options).not.toHaveProperty("entitiesDir");
-		expect(connection.logger instanceof Logger).toBeTruthy();
-		expect(connection.entityManager.entities).toStrictEqual({
-			// eslint-disable-next-line @typescript-eslint/naming-convention
-			TestEntity: {
-				columns: [
-					{ databaseName: "id", name: "id", primary: true, type: String },
-					{ databaseName: "foo", name: "foo", type: Number },
-				],
-				databaseName: "TestEntity",
-				name: "TestEntity",
-			},
+
+		it("should get connection default config", async () => {
+			@Entity()
+			class TestEntity {
+				@PrimaryColumn()
+				public id: string;
+
+				@Column()
+				public foo: number;
+			}
+
+			const options: BaseConnectionOptions = {
+				entities: [TestEntity],
+			};
+
+			const connection = new TestConnection(options);
+			await connection.load();
+
+			expect(connection.name).toBe("Default");
+			expect(connection.options).toStrictEqual({
+				plugin,
+			});
+			expect(connection.entities).toStrictEqual(options.entities);
+			expect(connection.options).not.toHaveProperty("entities");
+			expect(connection.options).not.toHaveProperty("entitiesDir");
+			expect(connection.logger instanceof Logger).toBeTruthy();
+			expect(connection.entityManager.entities).toStrictEqual({
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				TestEntity: {
+					columns: [
+						{ databaseName: "id", name: "id", primary: true, type: String },
+						{ databaseName: "foo", name: "foo", type: Number },
+					],
+					databaseName: "TestEntity",
+					name: "TestEntity",
+				},
+			});
+		});
+
+		it("should get connection custom config", async () => {
+			@Entity()
+			class TestEntity {
+				@PrimaryColumn()
+				public id: string;
+
+				@Column()
+				public foo: number;
+			}
+
+			const baseOptions: BaseConnectionOptions = {
+				name: "Custom",
+				namingStrategy: {
+					entity: "PascalCase",
+					column: "snake_case",
+				},
+				logging: "MINIMUM",
+				prefix: {
+					entity: {
+						add: "add",
+					},
+					column: {
+						remove: "remove",
+					},
+				},
+			};
+
+			const options = {
+				...baseOptions,
+				entities: [TestEntity],
+			};
+
+			const connection = new TestConnection(options);
+			await connection.load();
+
+			expect(connection.name).toBe("Custom");
+			expect(connection.options).toStrictEqual({
+				...baseOptions,
+				plugin,
+			});
+			expect(connection.entities).toStrictEqual(options.entities);
+			expect(connection.options).not.toHaveProperty("entities");
+			expect(connection.options).not.toHaveProperty("entitiesDir");
+			expect(connection.logger instanceof Logger).toBeTruthy();
+			expect(connection.entityManager.entities).toStrictEqual({
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				TestEntity: {
+					columns: [
+						{ databaseName: "id", name: "id", primary: true, type: String },
+						{ databaseName: "foo", name: "foo", type: Number },
+					],
+					databaseName: "AddTestEntity",
+					name: "TestEntity",
+				},
+			});
 		});
 	});
 
-	it("should get connection custom config", async () => {
-		@Entity()
-		class TestEntity {
-			@PrimaryColumn()
-			public id: string;
+	describe("Connection `basicValidate`", () => {
+		it("should throw error load empty array of entities", async () => {
+			const options: BaseConnectionOptions = {
+				entitiesDir: [],
+			};
 
-			@Column()
-			public foo: number;
-		}
+			const connection = new TestConnection(options);
+			await connection.load();
 
-		const baseOptions: BaseConnectionOptions = {
-			name: "Custom",
-			namingStrategy: {
-				entity: "PascalCase",
-				column: "snake_case",
-			},
-			logging: "MINIMUM",
-			prefix: {
-				entity: {
-					add: "add",
-				},
-				column: {
-					remove: "remove",
-				},
-			},
-		};
+			let result: any;
 
-		const options = {
-			...baseOptions,
-			entities: [TestEntity],
-		};
+			try {
+				result = connection.testBasicValidate();
+			} catch (err: any) {
+				result = err;
+			}
 
-		const connection = new TestConnection(options);
-		await connection.load();
-
-		expect(connection.name).toBe("Custom");
-		expect(connection.options).toStrictEqual({
-			...baseOptions,
-			plugin: "@techmmunity/utils",
-		});
-		expect(connection.entities).toStrictEqual(options.entities);
-		expect(connection.options).not.toHaveProperty("entities");
-		expect(connection.options).not.toHaveProperty("entitiesDir");
-		expect(connection.logger instanceof Logger).toBeTruthy();
-		expect(connection.entityManager.entities).toStrictEqual({
-			// eslint-disable-next-line @typescript-eslint/naming-convention
-			TestEntity: {
-				columns: [
-					{ databaseName: "id", name: "id", primary: true, type: String },
-					{ databaseName: "foo", name: "foo", type: Number },
-				],
-				databaseName: "AddTestEntity",
-				name: "TestEntity",
-			},
+			expect(result instanceof SymbiosisError).toBeTruthy();
+			expect(result).toStrictEqual(
+				new SymbiosisError({
+					code: "MISSING_PARAM",
+					origin: "SYMBIOSIS",
+					message: "Missing entities",
+					details: [
+						"No entities found",
+						"`entities` option:",
+						undefined,
+						"`entitiesDir` option:",
+						[],
+					],
+				}),
+			);
 		});
 	});
 

--- a/src/tests/constants/test-connection.ts
+++ b/src/tests/constants/test-connection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { BaseConnection } from "../../lib/connection";
@@ -7,11 +8,19 @@ import { TestRepository } from "./test-repository";
 
 export class TestConnection extends BaseConnection {
 	public constructor(options?: BaseConnectionOptions) {
-		// Example name of a installed package
+		// Example name of a INSTALLED package
 		super("@techmmunity/utils", options);
 	}
 
+	public testBasicValidate() {
+		super.basicValidate();
+	}
+
 	public connect(): Promise<this> {
+		throw new Error("Method not implemented.");
+	}
+
+	public validate(): Promise<void> {
 		throw new Error("Method not implemented.");
 	}
 


### PR DESCRIPTION
## What this PR introduces?

Issue Number: N/A
PR Of Documentation Update: N/A

<!-- Please, includes description of this pull request -->

### Added

- [BC] `validate` method to `BaseConnection`
  - Will be used to validate connection data
  - Ex: If mongodb plugin, validate if all entities have only one primary column, and it's name is `_id`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] My contribution follows [the guidelines](https://github.com/techmmunity/symbiosis/blob/master/CONTRIBUTING.md)
- [x] I followed [GitFlow](https://github.com/techmmunity/git-magic/blob/master/docs/en/gitflow.md) pattern to create the branch
- [x] Tests for the changes have been added
- [ ] I created a PR to add / update the documentation (or aren't necessary)
- [x] The changes has been added to `CHANGELOG.md`
- [x] My code produces no warnings or errors

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
[ ] Other: ...
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Add `validate` method to `BaseConnection`

## Other information (Prints, details, etc)
